### PR TITLE
Update get_relations_by_pattern.sql

### DIFF
--- a/macros/sql/get_relations_by_pattern.sql
+++ b/macros/sql/get_relations_by_pattern.sql
@@ -1,12 +1,12 @@
-{% macro get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
-    {{ return(adapter.dispatch('get_relations_by_pattern', 'dbt_utils')(schema_pattern, table_pattern, exclude, database)) }}
+{% macro get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database,quoting=false) %}
+    {{ return(adapter.dispatch('get_relations_by_pattern', 'dbt_utils')(schema_pattern, table_pattern, exclude, database,quoting)) }}
 {% endmacro %}
 
-{% macro default__get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database) %}
+{% macro default__get_relations_by_pattern(schema_pattern, table_pattern, exclude='', database=target.database, quoting=false) %}
 
     {%- call statement('get_tables', fetch_result=True) %}
 
-      {{ dbt_utils.get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude, database) }}
+      {{ dbt_utils.get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude, database, quoting) }}
 
     {%- endcall -%}
 


### PR DESCRIPTION
The get_relations_by_pattern macro does not work if the source tables in the database dont have a valid name (for example in our case the name included double --).
I added an additional parameter "quoting" and set the default value to ==false.
If the parameter quoting==true in the get_relations_by_pattern then it returns a table name from information_schema.tables in double quotes and that fixes the problem. 
If the parameter in a macro call is ommited, everything works as until now.

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/dbt-labs/dbt-utils/blob/main/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
